### PR TITLE
Use correct import

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See [ContinueRequestOverrides](https://pptr.dev/api/puppeteer.continuerequestove
 ## Usage
 #### Importing:
 ```js
-const useProxy = require('puppeteer-page-proxy');
+const useProxy = require('@lem0-packages/puppeteer-page-proxy');
 ```
 
 #### Proxy per page:


### PR DESCRIPTION
See [puppeteer-page-proxy package not found on import](https://stackoverflow.com/questions/78043706/puppeteer-page-proxy-package-not-found-on-import/78043784#78043784)